### PR TITLE
Adding onPreStart

### DIFF
--- a/friend-selector/jquery.friend.selector-1.2.1.js
+++ b/friend-selector/jquery.friend.selector-1.2.1.js
@@ -24,6 +24,7 @@
       return false;
     }
 
+    fsOptions.onPreStart();
     fsOptions = $.extend(true, {}, defaults, fsOptions);
 
     if ( fsOptions.max > 0 && fsOptions.max !== null ) {
@@ -588,6 +589,7 @@
     maxFriendsCount: null,
     showRandom: false,
     facebookInvite: true,
+    onPreStart: function(response){ return null; },
     onStart: function(response){ return null; },
     onClose: function(response){ return null; },
     onSubmit: function(response){ return null; }


### PR DESCRIPTION
This is to get a predefined config, when you select some ppl and save the dialog and then you open the dialog again the getStoredFriends is cleaned.... for some applications is usefull restore the friends selected and stored in an input, Example:

$(".who_share").fSelector({
          getStoredFriends: [<?=!empty($amigos)?$amigos:""?>],
          closeOnSubmit: true,
          facebookInvite: false,
          onSubmit: function(response){
            $('#priv_sel').removeClass().addClass('icon-group');
            $('#priv_opcs>li').show();
            $('input[name=privacidad]').val(3);
            alertify.log('Publicación Personalizada');
            $('input[name=amigos]').val(response);
          },
          onPreStart: function(response){
            facebook_friends = $('input[name=amigos]').val().split(",")
            for(var i=0; i<facebook_friends.length; i++){
                facebook_friends[i] = parseInt(facebook_friends[i], 10)
            }
            this.getStoredFriends= facebook_friends;
          }
        });
