### PR TITLE
Fixed onPreStart, spaces in friend filter, and backspacing in filter

### DIFF
--- a/friend-selector/jquery.friend.selector-1.2.1.js
+++ b/friend-selector/jquery.friend.selector-1.2.1.js
@@ -24,8 +24,8 @@
       return false;
     }
 
-    fsOptions.onPreStart();
     fsOptions = $.extend(true, {}, defaults, fsOptions);
+    fsOptions.onPreStart();
 
     if ( fsOptions.max > 0 && fsOptions.max !== null ) {
       fsOptions.showSelectedCount = true;
@@ -232,7 +232,7 @@
     var item = $('<li/>');
 
     var link =  '<a class="fs-anchor" href="javascript://">' +
-                  '<input class="fs-fullname" type="hidden" name="fullname[]" value="'+v[k].name.toLowerCase().replace(/\s/gi, "+")+'" />' +
+                  '<input class="fs-fullname" type="hidden" name="fullname[]" value="'+v[k].name.toLowerCase().replace(/\s/gi, "0")+'" />' +
                   '<input class="fs-friends" type="checkbox" name="friend[]" value="fs-'+v[k].id+'" />' +
                   '<img class="fs-thumb" src="https://graph.facebook.com/'+v[k].id+'/picture" />' +
                   '<span class="fs-name">' + _charLimit(v[k].name, 15) + '</span>' +
@@ -362,13 +362,32 @@
   _find = function(t) {
 
     var fs_dialog = $('#fs-dialog');
+    var container = $('#fs-user-list ul');
 
     search_text_base = $.trim(t.val());
-    var search_text = search_text_base.toLowerCase().replace(/\s/gi, '+');
+
+    if(search_text_base === ''){
+      $.each(container.children(), function(){
+        $(this).show();
+      });
+
+      if ( fs_dialog.has('#fs-summary-box').length ){
+        if ( selected_friend_count === 1 ){
+          $('#fs-summary-box').remove();
+        }
+        else{
+          $('#fs-result-text').remove();
+        }
+
+      }
+      return;
+    }
+
+    var search_text = search_text_base.toLowerCase().replace(/\s/gi, '0');
 
     var elements = $('#fs-user-list .fs-fullname[value*='+search_text+']');
 
-    var container = $('#fs-user-list ul');
+   
     container.children().hide();
     $.each(elements, function(){
       $(this).parents('li').show();
@@ -392,19 +411,6 @@
     }
     else {
       $('#fs-result-text').text(result_text);
-    }
-
-    if ( search_text_base === '' ){
-      if ( fs_dialog.has('#fs-summary-box').length ){
-
-        if ( selected_friend_count === 1 ){
-          $('#fs-summary-box').remove();
-        }
-        else{
-          $('#fs-result-text').remove();
-        }
-
-      }
     }
 
   },


### PR DESCRIPTION
-onPreStart bug:
  onPreStart() was called before the fsOptions were filled in with
defaults causing an error whenever fSelector was used without
specifying onPreStart()

Uncaught TypeError: Object #<Object> has no method 'onPreStart'

-Spaces in friend filter bug:
  Everytime you put a space in the friend filter box, the css attribute
selector wouldn't work because the spaces were being replaced by '+'s.
I believe some symbols just don't work in those selectors?  I tried +
and &.  I just ended up using a 0 to replace spaces by, but if
something that's not a number works that would be great.

Example error:
Uncaught Error: Syntax error, unrecognized expression: #fs-user-list
.fs-fullname[value*=jessica+c]

-Backspacing in friend filter bug:
  If you filtered friends by some string (ex: "jes"), but then
backspaced so that you had nothing in the filter box, no friends would
show up because the attribute selector value*=search_text was still
being performed, but search_text was an empty string
