### PR TITLE
design twics: profileImageZoom, profileImageRotate & FB api 2.0 

### DIFF
--- a/friend-selector/jquery.friend.selector-1.2.1.css
+++ b/friend-selector/jquery.friend.selector-1.2.1.css
@@ -13,12 +13,19 @@
   font-size: 11px;
   line-height: normal !important;
   
-  width: 555px
+  width: 555px;
+
 }
 #fs-dialog input:focus {
   outline: none
 }
 
+.fs-transition {
+    -webkit-transform: scale(1.4); 
+    -moz-transform: scale(1.4);
+    -o-transform: scale(1.4);
+    transform: scale(1.4);
+}
 
 /* @group Title */
 
@@ -135,7 +142,7 @@
   float: left;
   padding: 5px 0 0 5px;
   width: 173px;
-  overflow: hidden
+  /*overflow: hidden*/
 }
 
 .fs-anchor {
@@ -149,12 +156,12 @@
   
   display: block;
   padding: 2px;
-  overflow: hidden
+  /*overflow: hidden*/
 }
 .fs-anchor:hover {
-  background-color: #eceff5;
-  border-color: #eceff5;
-  
+  /*background-color: #eceff5;
+  border-color: #eceff5;*/
+  color: #000!important;
   text-decoration: none !important
 }
 li.checked .fs-anchor {
@@ -167,12 +174,24 @@ li.checked .fs-anchor {
   margin: 6px 6px 0
 }
 .fs-thumb {
-  border: none;
-
+  border: 1px solid gray;
   float: left;
-  height: 30px;
+  height: 35px;
   margin-right: 5px;
-  width: 30px
+  padding: 2px;
+  width: 35px;
+
+  -webkit-transition: all .2s ease-in-out;
+  -moz-transition: all .2s ease-in-out;
+  -ms-transition: all .2s ease-in-out;
+  -o-transition: all .2s ease-in-out;
+}
+
+.fs-img-container{
+  -webkit-transition: all .2s ease-in-out;
+  -moz-transition: all .2s ease-in-out;
+  -ms-transition: all .2s ease-in-out;
+  -o-transition: all .2s ease-in-out;
 }
 .fs-name {
   display: table-cell;
@@ -299,8 +318,8 @@ li.checked .fs-anchor {
   border-color: #212a30
 }
 .fs-color-dark .fs-anchor:hover {
-  background-color: #ededed;
-  border-color: #ededed
+  /*background-color: #ededed;
+  border-color: #ededed*/
 }
 .fs-color-dark li.checked .fs-anchor {
   background-color: #ddd;
@@ -629,4 +648,9 @@ li.checked .fs-anchor {
   position: absolute;
   top: 50%;
   left: 50%;
+}
+
+.fs-img-container{
+  display: table-cell;
+  vertical-align: bottom;
 }

--- a/friend-selector/jquery.friend.selector-1.2.1.js
+++ b/friend-selector/jquery.friend.selector-1.2.1.js
@@ -60,12 +60,15 @@
 
     var selected_friends = [];
     $('input.fs-friends:checked').each(function(){
-      selected_friends.push(parseInt($(this).val().split('-')[1], 10));
+      //had to change it after changing /me/friends to /me/invitable_friends
+      //selected_friends.push(parseInt($(this).val().split('-')[1], 10));
+      selected_friends.push($(this).data('id'));
     });
 
     if ( fsOptions.facebookInvite === true ){
       
-      var friends = selected_friends.join();
+      //var friends = selected_friends.join();
+      var friends = selected_friends.join(',');
 
       FB.ui({
         method: 'apprequests',
@@ -169,7 +172,7 @@
       
     } else {
     
-      FB.api('/me/friends', function(response){
+      FB.api('/me/invitable_friends', function(response){
         _parseFacebookFriends(response);
       }); 
     }
@@ -230,13 +233,25 @@
   _setFacebookFriends = function (k, v, predefined) {
 
     var item = $('<li/>');
+    var number = 0;
 
-    var link =  '<a class="fs-anchor" href="javascript://">' +
+    if ( fsOptions.profileImageRotate === true ) {
+      number = _randomBetween(-5,5);
+    }
+
+    var initial_link =  '<a class="fs-anchor" href="javascript://">' +
                   '<input class="fs-fullname" type="hidden" name="fullname[]" value="'+v[k].name.toLowerCase().replace(/\s/gi, "0")+'" />' +
                   '<input class="fs-friends" type="checkbox" name="friend[]" value="fs-'+v[k].id+'" />' +
                   '<img class="fs-thumb" src="https://graph.facebook.com/'+v[k].id+'/picture" />' +
                   '<span class="fs-name">' + _charLimit(v[k].name, 15) + '</span>' +
                 '</a>';
+    var link =  '<a class="fs-anchor" href="javascript://">' +
+              '<input class="fs-fullname" type="hidden" name="fullname[]" value="'+v[k].name.toLowerCase().replace(/\s/gi, "0")+'" />' +
+              '<input class="fs-friends" type="checkbox" name="friend[]" value="fs-'+v[k].id+'" data-id="'+v[k].id+'" />' +
+              '<div class="fs-img-container" style="-webkit-transform: rotate('+number+'deg); transform: rotate('+number+'deg);">'+
+              '<img  class="fs-thumb" src="'+v[k].picture.data.url+'" /> </div>' +
+              '<span class="fs-name">' + _charLimit(v[k].name, 15) + '</span>' +
+            '</a>';
 
     item.append(link);
 
@@ -302,6 +317,9 @@
       overlay.bind('click.fs', _close);
     }
 
+    if ( fsOptions.profileImageZoom === true ) {
+      _profileImageZoom();
+    }
   },
 
   _select = function(th) {
@@ -357,6 +375,21 @@
 
     return word.substr(0, limit) + '...';
 
+  },
+
+  _profileImageZoom = function(){
+    $(document).on('mouseover','.fs-anchor',function(){
+      $(this).find('img.fs-thumb').addClass('fs-transition');
+    });
+
+
+    $(document).on('mouseout','.fs-anchor',function(){
+        $(this).find('img.fs-thumb').removeClass('fs-transition');
+    });
+  },
+
+  _randomBetween  = function(min, max){
+    return Math.floor(Math.random() * (max - min + 1)) + min;
   },
 
   _find = function(t) {
@@ -576,6 +609,8 @@
     showButtonSelectAll: true,
     addUserGroups: false,
     color: "default",
+    profileImageZoom: true,
+    profileImageRotate: true,
     lang: {
       title: "Friend Selector",
       buttonSubmit: "Send",


### PR DESCRIPTION
1. applied changes reported in https://github.com/codersgrave/Facebook-Friend-Selector/issues/18
2. added design enhancements: profileImageZoom and profileImageRotate.
- only css difference that is visible if both new properties are set to False is a border on the profileImage.

Selector would now look like this:
![screen shot 2014-08-02 at 11 06 05 pm](https://cloud.githubusercontent.com/assets/4998079/3789102/e2acdc30-1a8b-11e4-80a2-49cd2119d858.png)
